### PR TITLE
Replace axios with native fetch API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "autoprefixer": "^10.4.13",
-        "axios": "^1.1.3",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "next-auth": "^4.16.4",
@@ -2509,18 +2508,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -4403,27 +4390,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8133,13 +8099,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/psl": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "autoprefixer": "^10.4.13",
-    "axios": "^1.1.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "next-auth": "^4.16.4",

--- a/pages/api/addTracks.ts
+++ b/pages/api/addTracks.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import axios from 'axios'
 
 const Handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const body = req.body
@@ -25,15 +24,10 @@ const Handler = async (req: NextApiRequest, res: NextApiResponse) => {
 }
 
 const addTracks = async(headers: {[key: string]: string}, playListId: string, uris: string[]) => {
-  const data = {
-    uris: uris,
-  }
-
-  const response = await axios({
+  const response = await fetch(`https://api.spotify.com/v1/playlists/${playListId}/tracks`, {
     method: 'POST',
-    url: `https://api.spotify.com/v1/playlists/${playListId}/tracks`,
     headers: headers,
-    data: data
+    body: JSON.stringify({ uris: uris }),
   })
 
   return response

--- a/pages/api/eachTrack.ts
+++ b/pages/api/eachTrack.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import axios from 'axios'
 
 const EachTrack = async (req: NextApiRequest, res: NextApiResponse) => {
   const body = req.body
@@ -20,16 +19,18 @@ const getTrackId = async (token: any, ids: any, artistId: string) => {
 
   for (const id of ids) {
     const severalId = id.join(',')
-    const response = await axios.get(`https://api.spotify.com/v1/albums`, {
-      params: {
-          'ids': severalId,
-      },
-      headers: {
-          Authorization: `Bearer ${token}`
-        }
-      })
+    const params = new URLSearchParams({
+      'ids': severalId,
+    })
 
-    albums = albums.concat(response.data.albums)
+    const response = await fetch(`https://api.spotify.com/v1/albums?${params}`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+
+    const data = await response.json()
+    albums = albums.concat(data.albums)
     if (response.status != 200) {
       status = response.status
       break

--- a/pages/api/playList.ts
+++ b/pages/api/playList.ts
@@ -1,30 +1,25 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import axios from 'axios'
 
 const Playlist = async (req: NextApiRequest, res: NextApiResponse) => {
   const body = req.body
   const id = body.id
   const playlistName = body.name
 
-  const headers = {
-    Authorization: `Bearer ${body.token}`,
-    'Content-Type': 'application/json; charset=utf-8',
-  }
-
-  const data = {
-    name: playlistName,
-    description: 'Playlist created by Srive',
-    public: false,
-  }
-
-  const response = await axios({
+  const response = await fetch(`https://api.spotify.com/v1/users/${id}/playlists`, {
     method: 'POST',
-    url: `https://api.spotify.com/v1/users/${id}/playlists`,
-    headers: headers,
-    data: data
+    headers: {
+      Authorization: `Bearer ${body.token}`,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify({
+      name: playlistName,
+      description: 'Playlist created by Srive',
+      public: false,
+    }),
   })
 
-  res.status(response.status).json({ data: response.data })
+  const data = await response.json()
+  res.status(response.status).json({ data: data })
 }
 
 export default Playlist

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import axios from 'axios'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const body = req.body
@@ -8,16 +7,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 async function searchSpotify(token: string, artistName: string) {
-  const response = await axios.get('https://api.spotify.com/v1/search', {
-    params: {
-        'query': artistName,
-        'type': 'artist',
-        'locale': 'ja'
-    },
-    headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
+  const params = new URLSearchParams({
+    'query': artistName,
+    'type': 'artist',
+    'locale': 'ja'
+  })
 
-  return response
+  const response = await fetch(`https://api.spotify.com/v1/search?${params}`, {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  return { status: response.status, data: await response.json() }
 }

--- a/pages/api/tracks.ts
+++ b/pages/api/tracks.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import axios from 'axios'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const body = req.body
@@ -18,15 +17,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 async function getTracks(token: string, id: string, groups: string = 'album,single') {
-  const response = await axios.get(`https://api.spotify.com/v1/artists/${id}/albums`, {
-    params: {
-        'include_groups': groups,
-        'limit': 50,
-    },
-    headers: {
-        Authorization: `Bearer ${token}`
-      }
-    })
+  const params = new URLSearchParams({
+    'include_groups': groups,
+    'limit': '50',
+  })
 
-  return response
+  const response = await fetch(`https://api.spotify.com/v1/artists/${id}/albums?${params}`, {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  return { status: response.status, data: await response.json() }
 }


### PR DESCRIPTION
Remove axios dependency and use the standard fetch API for all Spotify API calls, reducing bundle size and external dependencies.